### PR TITLE
Incorrect syntax to call load from $loader

### DIFF
--- a/DependencyInjection/KPhoenRulerZExtension.php
+++ b/DependencyInjection/KPhoenRulerZExtension.php
@@ -43,7 +43,7 @@ class KPhoenRulerZExtension extends Extension
     {
         foreach ($this->supportedExecutors as $executor) {
             if ($config['executors'][$executor]) {
-                $loader-load(sprintf('executors/%s.yml', $executor));
+                $loader->load(sprintf('executors/%s.yml', $executor));
             }
         }
     }


### PR DESCRIPTION
The > sign was not present for calling the load on $loader
