### PR TITLE
Remove Symfony 3.0 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     fast_finish: true
     include:
         - php: 5.6
-          env: COMPOSER_FLAGS="--prefer-lowest"
-        - php: 5.6
-          env: SYMFONY_VERSION=2.3.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.4.*
-        - php: 5.6
           env: SYMFONY_VERSION=2.5.*
         - php: 5.6
           env: SYMFONY_VERSION=2.6.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,26 @@ cache:
         - vendor
         - $HOME/.composer/cache
 
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.6
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.4.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.5.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.6.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*
+
 php:
     - 5.4
     - 5.5
@@ -16,11 +36,14 @@ php:
     - 7.0
     - hhvm
 
-before_script:
+before_install:
     - composer self-update
     # disable xdebug since we don't use code-coverage for now
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
-install: composer install --prefer-source
+install:
+    - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
-script: ./vendor/bin/phpunit
+script:
+    - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ php:
 
 before_install:
     - composer self-update
+    - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
     # disable xdebug since we don't use code-coverage for now
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
@@ -40,4 +41,4 @@ install:
     - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-    - phpunit
+    - ./vendor/bin/phpunit

--- a/Resources/config/debug.yml
+++ b/Resources/config/debug.yml
@@ -4,5 +4,5 @@ services:
 
     rulerz.compiler.eval:
         class:      RulerZ\Compiler\EvalCompiler
-        arguments:  [ @rulerz.parser ]
+        arguments:  [ "@rulerz.parser" ]
         public: false

--- a/Resources/config/rulerz.yml
+++ b/Resources/config/rulerz.yml
@@ -1,7 +1,7 @@
 services:
     rulerz:
         class:      RulerZ\RulerZ
-        arguments:  [ @rulerz.compiler ]
+        arguments:  [ "@rulerz.compiler" ]
 
     rulerz.compiler:
         alias:  rulerz.compiler.file
@@ -10,7 +10,7 @@ services:
     rulerz.compiler.file:
         class:      RulerZ\Compiler\FileCompiler
         public:     false
-        arguments:  [ @rulerz.parser, %rulerz.cache_directory% ]
+        arguments:  [ "@rulerz.parser", %rulerz.cache_directory% ]
 
     rulerz.parser:
         class:  RulerZ\Parser\HoaParser

--- a/Resources/config/validators.yml
+++ b/Resources/config/validators.yml
@@ -1,6 +1,6 @@
 services:
     rulerz.validator.unique.rule_validator:
         class:     KPhoen\RulerZBundle\Validator\Constraints\RuleValidator
-        arguments: [ @rulerz.parser ]
+        arguments: [ "@rulerz.parser" ]
         tags:
             - { name: validator.constraint_validator, alias: rulerz_rule_validator }

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "kphoen/rulerz": "~0.1, >=0.13.0",
-        "symfony/validator": "~2.3|~3.0",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "symfony/validator": "~2.5|~3.0",
+        "symfony/framework-bundle": "~2.5|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
+        "symfony/phpunit-bridge": "~2.7|~3.0",
         "mikey179/vfsStream": "~1.0",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7"
     }


### PR DESCRIPTION
Remove Symfony 3.0 deprecation and run test on many Symfony version

> Not quoting the scalar "@rulerz.parser " starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0

Require: https://github.com/K-Phoen/rulerz/pull/29
