### PR TITLE
rulerz 0.17 as the latest minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr-4": { "KPhoen\\RulerZBundle\\": "" }
     },
     "require": {
-        "kphoen/rulerz": "~0.1, >=0.13.0",
+        "kphoen/rulerz": "~0.17",
         "symfony/validator": "~2.5|~3.0",
         "symfony/framework-bundle": "~2.5|~3.0"
     },


### PR DESCRIPTION
Because RulerZ 0.17 drops PHP5.4 support, we must drop it here too.
