### PR TITLE
Fix yaml validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
           env: SYMFONY_VERSION=2.8.*
         - php: 5.6
           env: SYMFONY_VERSION=3.0.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.1.*
 
 php:
     - 5.5
@@ -40,4 +42,4 @@ install:
     - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-    - ./vendor/bin/phpunit
+    - ./vendor/bin/phpunit -v

--- a/Resources/config/rulerz.yml
+++ b/Resources/config/rulerz.yml
@@ -10,7 +10,7 @@ services:
     rulerz.compiler.file:
         class:      RulerZ\Compiler\FileCompiler
         public:     false
-        arguments:  [ "@rulerz.parser", %rulerz.cache_directory% ]
+        arguments:  [ "@rulerz.parser", "%rulerz.cache_directory%" ]
 
     rulerz.parser:
         class:  RulerZ\Parser\HoaParser


### PR DESCRIPTION
> Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0

This allow Travis to not fail on Symfony 3.1 project.
I missed that one in my previous PR (https://github.com/K-Phoen/RulerZBundle/pull/3).
