### PR TITLE
Fix value of debug parameter when not overridden in configuration file

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-                ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
+                ->booleanNode('debug')->defaultNull()->end()
             ->end();
 
         return $rootNode;

--- a/DependencyInjection/KPhoenRulerZExtension.php
+++ b/DependencyInjection/KPhoenRulerZExtension.php
@@ -19,6 +19,11 @@ class KPhoenRulerZExtension extends Extension
         $loader->load('rulerz.yml');
         $loader->load('validators.yml');
 
+        if (!is_bool($config['debug'])) {
+            $parameterBag = $container->getParameterBag();
+            $config['debug'] = $parameterBag->has('kernel.debug') ? $parameterBag->get('kernel.debug') : true;
+        }
+
         if ($config['debug']) {
             $loader->load('debug.yml');
         }


### PR DESCRIPTION
When "debug" parameter is not defined in configuration files, its default value is supposed to be the value of Symfony parameter "kernel.debug".

Problem : instead of getting the value of "kernel.debug" (which is supposed to be a boolean), parameter "debug" is literraly equal to the string "kernel.debug", which means that condition
```
if ($config['debug']) 
```
 always returns true, even if "kernel.debug" parameter is set as false.

Consequence : if Rulerz bundle configuration is not defined in the Symfony project, debug mode is always set to on (no matter the environment)    