### PR TITLE
Add OOB support for doctrine_dbal target

### DIFF
--- a/DependencyInjection/KPhoenRulerZExtension.php
+++ b/DependencyInjection/KPhoenRulerZExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\FileLocator;
 
 class KPhoenRulerZExtension extends Extension
 {
-    private $supportedTargets = ['native', 'doctrine', 'eloquent', 'pomm', 'elastica', 'elasticsearch'];
+    private $supportedTargets = ['native', 'doctrine', 'doctrine_dbal', 'eloquent', 'pomm', 'elastica', 'elasticsearch'];
 
     public function load(array $configs, ContainerBuilder $container)
     {


### PR DESCRIPTION
As in the title, because `doctrine_dbal` was not listed in extension supported targets list, config entry `doctrine_dbal` was not being enabled.