### PR TITLE
Command auto-registration not available in Symfony 4

### DIFF
--- a/Resources/config/rulerz.yml
+++ b/Resources/config/rulerz.yml
@@ -20,3 +20,8 @@ services:
     rulerz.parser:
         class: RulerZ\Parser\Parser
         public: false
+
+    KPhoen\RulerZBundle\Command\CacheClearCommand:
+        public: true
+        tags:
+            - { 'name': 'console.command' }

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         "php": ">=7.1",
         "kphoen/rulerz": "~0.17,>=0.19.3",
         "kphoen/rulerz-bridge": "^1.0",
-        "symfony/framework-bundle": "^3.0|^4.0"
+        "symfony/framework-bundle": "^3.3|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1",
-        "symfony/phpunit-bridge": "^3.0|^4.0",
+        "symfony/phpunit-bridge": "^3.3|^4.0",
         "mikey179/vfsStream": "~1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "liip/rmt": "^1.2"


### PR DESCRIPTION
 Fix `Auto-registration of the command "KPhoen\RulerZBundle\Command\CacheClearCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0`

I dropped the support for Symfony < 3.3 because class name as service has been introduced in 3.3 and Symfony < 3.4 is not maintainted anymore but I can re-add it if needed